### PR TITLE
Avoid missing context

### DIFF
--- a/classes/shortcodes.php
+++ b/classes/shortcodes.php
@@ -65,7 +65,12 @@ class shortcodes {
             return '';
         }
 
-        $context = $env->context->get_course_context(false);
+        if ($env->context) {
+            $context = $env->context->get_course_context(false);
+        } else {
+            $context = $PAGE->context->get_course_context(false);
+        }
+
         if (!$context) {
             return '';
         }


### PR DESCRIPTION
If you use the stash shortcodes in a block (e.g. block_html) and you have

* (at least) two objects,
* the first of them has a non-empty description (simple text is enough) and
* shortcodes for both of the objects inside the block,

then you get 

`Call to a member function get_course_context() on null`

making it impossible to access the page again. This does not affect course modules (e.g. mod_label). Thanks to @fdagner for discovering this!

The problem occurrs as $this->env is set to null in [https://github.com/branchup/moodle-filter_shortcodes/blob/dfde0e7a1bfbc2148b1827060b05530c6d480ccb/classes/local/processor/standard_processor.php#L101](https://github.com/branchup/moodle-filter_shortcodes/blob/dfde0e7a1bfbc2148b1827060b05530c6d480ccb/classes/local/processor/standard_processor.php#L101) and can be avoided by using $PAGE->context if $this->env->context is not available.

