### PR TITLE
Fix: unit tests fail, VALUE_OPTIONAL can't be used in top level param…

### DIFF
--- a/classes/external/save_removal.php
+++ b/classes/external/save_removal.php
@@ -39,7 +39,7 @@ class save_removal extends external_api {
                     'quantity' => new external_value(PARAM_INT),
                 ])
             ),
-            'removalid' => new external_value(PARAM_INT, '', VALUE_OPTIONAL)
+            'removalid' => new external_value(PARAM_INT, '', VALUE_DEFAULT)
         ]);
     }
 


### PR DESCRIPTION
Hi Adrian,

The recent updates from "block_stash" plugin breaks the unit tests, I looked for an explanation and found  following in the Moodle docs.  And it says "VALUE_OPTIONAL can't be used in top level parameters". 

[Link to the Moodle Web Service Documentation](https://moodledev.io/docs/4.5/apis/subsystems/external/writing-a-service#required-optional-or-default-value)

Unit tests are passing when we switch to "VALUE_DEFAULT".

Cheers,
Pramith.