### PR TITLE
Fix mustache filename, so that subtemplate gets shown correctly

### DIFF
--- a/templates/local/trade/item_table_data_loss.mustache
+++ b/templates/local/trade/item_table_data_loss.mustache
@@ -19,6 +19,6 @@
 </thead>
 <tbody>
 {{#lossitems}}
-    {{>block_stash/trade_add_item_detail}}
+    {{>block_stash/trade_loss_item_detail}}
 {{/lossitems}}
 </tbody>


### PR DESCRIPTION
There is a naming error in this mustache file, so that the other mustache file does not get shown correctly.